### PR TITLE
fix: set max height on select field

### DIFF
--- a/packages/saas-ui-select/src/select.tsx
+++ b/packages/saas-ui-select/src/select.tsx
@@ -116,7 +116,7 @@ export const Select = forwardRef<SelectProps, 'select'>((props, ref) => {
       <MenuButton as={SelectButton} ref={ref} {...buttonProps}>
         {displayValue || placeholder}
       </MenuButton>
-      <MenuList maxH="200" overflow="scroll">
+      <MenuList maxH="200" overflowY="auto">
         <MenuOptionGroup
           defaultValue={
             (defaultValue || value) as string | string[] | undefined

--- a/packages/saas-ui-select/src/select.tsx
+++ b/packages/saas-ui-select/src/select.tsx
@@ -116,7 +116,7 @@ export const Select = forwardRef<SelectProps, 'select'>((props, ref) => {
       <MenuButton as={SelectButton} ref={ref} {...buttonProps}>
         {displayValue || placeholder}
       </MenuButton>
-      <MenuList>
+      <MenuList maxH="200" overflow="scroll">
         <MenuOptionGroup
           defaultValue={
             (defaultValue || value) as string | string[] | undefined

--- a/packages/saas-ui-select/stories/select.stories.tsx
+++ b/packages/saas-ui-select/stories/select.stories.tsx
@@ -19,23 +19,17 @@ export default {
   ],
 }
 
-const options = [
-  {
-    value: '1',
-    label: 'Option 1',
-  },
-  {
-    value: '2',
-    label: 'Option 2',
-  },
-]
+const options = Array.from({ length: 100 }).map((_node, index) => ({
+  value: String(index),
+  label: `Option ${index + 1}`,
+}))
 
 const Template: ComponentStory<typeof Select> = (args) => <Select {...args} />
 
 export const basic = Template.bind({})
 basic.args = {
   /**
-   * Descripitioin
+   * Description
    */
   name: 'select',
   options,


### PR DESCRIPTION
Currently, if you have a lot of options provided to the select, the select doesn't overflow. Even with the select not being open, this can cause the entire page to expand past it's intended height and of course, when open, the select could be 1000px high

Before:
<img width="1561" alt="Screen Shot 2022-02-18 at 7 31 01 AM" src="https://user-images.githubusercontent.com/16495816/154690002-a68e9a2f-a4d0-4198-b18c-534d9971cf86.png">

After:
<img width="608" alt="Screen Shot 2022-02-18 at 7 30 28 AM" src="https://user-images.githubusercontent.com/16495816/154690027-ba3be96f-dac9-4438-8044-c797fd80ac50.png">
