### PR TITLE
Fixes Yup schema for StepForm examples with Yup

### DIFF
--- a/apps/website/src/pages/docs/forms/step-form.mdx
+++ b/apps/website/src/pages/docs/forms/step-form.mdx
@@ -86,9 +86,9 @@ function CreateProject() {
       name: Yup.string().required().label('Name'),
       description: Yup.string().label('Description'),
     }),
-    members: {
+    members: Yup.object().shape({
       members: Yup.string().label('Members'),
-    },
+    }),
   }
 
   const onSubmit = (params) => {
@@ -144,9 +144,9 @@ function CreateProject() {
       name: Yup.string().required().label('Name'),
       description: Yup.string().label('Description'),
     }),
-    members: {
+    members: Yup.object().shape({
       members: Yup.string().label('Members'),
-    },
+    }),
   }
 
   const onSubmit = (params) => {
@@ -229,9 +229,9 @@ function CreateProject() {
       name: Yup.string().required().label('Name'),
       description: Yup.string().label('Description'),
     }),
-    members: {
+    members: Yup.object().shape({
       members: Yup.string().label('Members'),
-    },
+    }),
   }
 
   const onSubmit = (params) => {


### PR DESCRIPTION
The example for StepForm with Yup, provided in the docs, was throwing an error. This was caused by passing in a plain object into Yup instead of a `Yup.object().shape`. This PR should fix the examples.