### PR TITLE
Added NPM install command on Getting Started

### DIFF
--- a/apps/website/src/pages/docs/getting-started.mdx
+++ b/apps/website/src/pages/docs/getting-started.mdx
@@ -25,6 +25,10 @@ Install Saas UI by running this:
 yarn add @saas-ui/react
 ```
 
+```bash
+npm i @saas-ui/react
+```
+
 ### Set up Provider
 
 For Saas UI to work correctly, you need to set up the `SaasProvider` at the


### PR DESCRIPTION
The Getting Started tutorial did not include the `npm` install command for getting saasUI up and running. Developers may have to go look through NPM to find it (if they aren't using yarn)