### PR TITLE
Update dialog to use props as labels

### DIFF
--- a/packages/saas-ui-modals/src/dialog.tsx
+++ b/packages/saas-ui-modals/src/dialog.tsx
@@ -116,7 +116,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
                   closeOnCancel && onClose()
                 }}
               >
-                Cancel
+                {cancelLabel}
               </Button>
               <Button
                 ref={confirmRef}
@@ -127,7 +127,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
                   closeOnConfirm && onClose()
                 }}
               >
-                Confirm
+                {confirmLabel}
               </Button>
             </ButtonGroup>
           </AlertDialogFooter>


### PR DESCRIPTION
I came across this while making use of saas-ui.

It would seem that although support is added for props to change labels of buttons, it is not implemented.

That's all this pr does. It implements it