### PR TITLE
fix(docs): useFormStepContext->useStepFormContext

### DIFF
--- a/apps/website/src/pages/docs/forms/step-form.mdx
+++ b/apps/website/src/pages/docs/forms/step-form.mdx
@@ -311,7 +311,7 @@ function CreateProject() {
 
 ## Access stepper state
 
-You can access the form step state by using render props or the `useFormStepContext` hook.
+You can access the form step state by using render props or the `useStepFormContext` hook.
 
 ```jsx
 function StepperState() {


### PR DESCRIPTION
While I was following this [tutorial](https://dev.to/eelcowiersma/building-a-multi-step-onboarding-flow-in-5-minutes-2176), I wanted to try accessing the stepper state as described in https://www.saas-ui.dev/docs/forms/step-form#access-stepper-state but I found out that `useFormStepContext` wasn't available so I checked out the source code and came across `useStepFormContext` which provided me with the values I needed.

replaced `useFormStepContext` with `useStepFormContext`