### PR TITLE
feat: surface auth form field labels for i18n

### DIFF
--- a/packages/saas-ui-auth/src/components/forgot-password-form.tsx
+++ b/packages/saas-ui-auth/src/components/forgot-password-form.tsx
@@ -24,6 +24,10 @@ interface SubmitParams {
 
 export interface ForgotPasswordFormProps
   extends Pick<FormProps<SubmitParams>, 'schema' | 'resolver' | 'children'> {
+  /**
+   * @deprecated use emailLabel instead
+   */
+  label?: string
   emailLabel?: string
   helpText?: string
   onSuccess?: (data: any) => void
@@ -39,6 +43,7 @@ export const ForgotPasswordForm: React.FC<ForgotPasswordFormProps> = ({
   onValidationError,
   submitLabel,
   emailLabel,
+  label,
   helpText,
   children,
   renderSuccess = () => (
@@ -69,7 +74,7 @@ export const ForgotPasswordForm: React.FC<ForgotPasswordFormProps> = ({
       <FormLayout>
         <Field
           name="email"
-          label={emailLabel}
+          label={emailLabel ?? label}
           type="email"
           rules={{ required: true }}
           autoComplete="email"

--- a/packages/saas-ui-auth/src/components/forgot-password-form.tsx
+++ b/packages/saas-ui-auth/src/components/forgot-password-form.tsx
@@ -24,7 +24,7 @@ interface SubmitParams {
 
 export interface ForgotPasswordFormProps
   extends Pick<FormProps<SubmitParams>, 'schema' | 'resolver' | 'children'> {
-  label?: string
+  emailLabel?: string
   helpText?: string
   onSuccess?: (data: any) => void
   onError?: (error: any) => void
@@ -38,7 +38,7 @@ export const ForgotPasswordForm: React.FC<ForgotPasswordFormProps> = ({
   onError = () => null,
   onValidationError,
   submitLabel,
-  label,
+  emailLabel,
   helpText,
   children,
   renderSuccess = () => (
@@ -69,7 +69,7 @@ export const ForgotPasswordForm: React.FC<ForgotPasswordFormProps> = ({
       <FormLayout>
         <Field
           name="email"
-          label={label}
+          label={emailLabel}
           type="email"
           rules={{ required: true }}
           autoComplete="email"
@@ -87,7 +87,7 @@ export const ForgotPasswordForm: React.FC<ForgotPasswordFormProps> = ({
 
 ForgotPasswordForm.defaultProps = {
   submitLabel: 'Reset password',
-  label: 'Your email address',
+  emailLabel: 'Your email address',
 }
 
 if (__DEV__) {

--- a/packages/saas-ui-auth/src/components/magic-link-form.tsx
+++ b/packages/saas-ui-auth/src/components/magic-link-form.tsx
@@ -23,6 +23,7 @@ export interface MagicLinkFormProps
   onError?: (error: any) => void
   onValidationError?: (error: FieldErrors<SubmitParams>) => void
   submitLabel?: string
+  emailLabel?: string
   defaultValues?: Record<string, any>
   renderSuccess?: (data: any) => React.ReactElement
 }
@@ -56,6 +57,7 @@ export const MagicLinkForm: React.FC<MagicLinkFormProps> = ({
   onError = () => null,
   onValidationError,
   submitLabel = 'Continue with Email',
+  emailLabel = 'Email',
   defaultValues,
   renderSuccess = (data) => <MagicLinkSuccess email={data?.email} />,
   children,
@@ -85,7 +87,7 @@ export const MagicLinkForm: React.FC<MagicLinkFormProps> = ({
       <FormLayout>
         <Field
           name="email"
-          label="Email"
+          label={emailLabel}
           type="email"
           rules={{ required: true }}
           autoComplete="email"

--- a/packages/saas-ui-auth/src/components/password-form.tsx
+++ b/packages/saas-ui-auth/src/components/password-form.tsx
@@ -32,6 +32,8 @@ export interface PasswordFormProps
   onError?: (error: any) => void
   onValidationError?: (error: FieldErrors<SubmitParams>) => void
   submitLabel?: string
+  emailLabel?: string
+  passwordLabel?: string
   defaultValues?: Record<string, any>
   renderSuccess?: (data: any) => React.ReactElement
 }
@@ -42,6 +44,8 @@ export const PasswordForm: React.FC<PasswordFormProps> = ({
   onError = () => null,
   onValidationError,
   submitLabel = 'Log in',
+  emailLabel = 'Email',
+  passwordLabel = 'Password',
   defaultValues,
   children,
   renderSuccess = () => (
@@ -73,14 +77,14 @@ export const PasswordForm: React.FC<PasswordFormProps> = ({
       <FormLayout>
         <Field
           name="email"
-          label="Email"
+          label={emailLabel}
           type="email"
           rules={{ required: true }}
           autoComplete="email"
         />
         <Field
           name="password"
-          label="Password"
+          label={passwordLabel}
           type="password"
           rules={{ required: true }}
           autoComplete="current-password"

--- a/packages/saas-ui-auth/src/components/update-password-form.tsx
+++ b/packages/saas-ui-auth/src/components/update-password-form.tsx
@@ -24,7 +24,7 @@ interface SubmitParams {
 
 export interface UpdatePasswordFormProps
   extends Pick<FormProps<SubmitParams>, 'schema' | 'resolver' | 'children'> {
-  label?: string
+  passwordLabel?: string
   confirmLabel?: string
   helpText?: string
   onSuccess?: (data: any) => void
@@ -39,7 +39,7 @@ export const UpdatePasswordForm: React.FC<UpdatePasswordFormProps> = ({
   onError = () => null,
   onValidationError,
   submitLabel,
-  label,
+  passwordLabel,
   confirmLabel,
   helpText,
   children,
@@ -69,7 +69,7 @@ export const UpdatePasswordForm: React.FC<UpdatePasswordFormProps> = ({
       <FormLayout>
         <Field
           name="password"
-          label={label}
+          label={passwordLabel}
           type="password"
           rules={{ required: true }}
           autoComplete="current-password"
@@ -95,7 +95,7 @@ export const UpdatePasswordForm: React.FC<UpdatePasswordFormProps> = ({
 
 UpdatePasswordForm.defaultProps = {
   submitLabel: 'Update password',
-  label: 'New password',
+  passwordLabel: 'New password',
   confirmLabel: 'Confirm password',
 }
 

--- a/packages/saas-ui-auth/src/components/update-password-form.tsx
+++ b/packages/saas-ui-auth/src/components/update-password-form.tsx
@@ -24,6 +24,10 @@ interface SubmitParams {
 
 export interface UpdatePasswordFormProps
   extends Pick<FormProps<SubmitParams>, 'schema' | 'resolver' | 'children'> {
+  /**
+   * @deprecated use passwordLabel instead
+   */
+  label?: string
   passwordLabel?: string
   confirmLabel?: string
   helpText?: string
@@ -40,6 +44,7 @@ export const UpdatePasswordForm: React.FC<UpdatePasswordFormProps> = ({
   onValidationError,
   submitLabel,
   passwordLabel,
+  label,
   confirmLabel,
   helpText,
   children,
@@ -69,7 +74,7 @@ export const UpdatePasswordForm: React.FC<UpdatePasswordFormProps> = ({
       <FormLayout>
         <Field
           name="password"
-          label={passwordLabel}
+          label={passwordLabel ?? label}
           type="password"
           rules={{ required: true }}
           autoComplete="current-password"


### PR DESCRIPTION
Surface auth form field labels for i18n on:
- magic-link-form
- password-form

refactor field labels to be uniformly named:
- update-password-form
- forgot-password-form