### PR TITLE
docs: auth docs typo fix

### DIFF
--- a/apps/website/src/pages/docs/components/auth/auth.mdx
+++ b/apps/website/src/pages/docs/components/auth/auth.mdx
@@ -67,7 +67,7 @@ The default authentication strategy is `magiclink`.
 <Stack maxW="400px">
   <Auth
     providers={{
-      google: {
+      github: {
         icon: FaGithub,
         name: 'Github',
       },


### PR DESCRIPTION
Although the `GitHub` icon is used in the auth documents, the Provider is defined as `Google`