### PR TITLE
Add children to line-chart

### DIFF
--- a/packages/saas-ui-charts/src/line-chart.tsx
+++ b/packages/saas-ui-charts/src/line-chart.tsx
@@ -39,6 +39,7 @@ export interface LineChartProps {
   variant?: 'line' | 'solid' | 'gradient'
   tooltipContent?(props: TooltipProps<any, any>): React.ReactNode
   tooltipFormatter?(value: string, name: string, props: any): string
+  children?: React.ReactNode
 }
 
 export const LineChart = (props: LineChartProps) => {
@@ -55,6 +56,7 @@ export const LineChart = (props: LineChartProps) => {
     tooltipFormatter = (value: string, name: string, props: any) => {
       return props.payload.yv
     },
+    children,
   } = props
 
   const theme = useTheme()
@@ -137,6 +139,8 @@ export const LineChart = (props: LineChartProps) => {
                   wrapperClassName={css(tooltipStyles)}
                   content={tooltipContent}
                 />
+                
+                {children}
 
                 <Area
                   type="monotone"


### PR DESCRIPTION
What do you think about line chart accepting children as an optional prop? I'd probably place it between Tooltip and Area in the component to sit on top of the right things.

My use case is customizability / an extension of the chart's features with out having to style a rechart from scratch. With Recharts having each chart feature as a separate component, I think this would be a great option.
