### PR TITLE
Fix(docs): add Card, CardBody, CardHeader as deprecated exports

### DIFF
--- a/apps/website/src/pages/docs/core/upgrading-to-v2.mdx
+++ b/apps/website/src/pages/docs/core/upgrading-to-v2.mdx
@@ -60,7 +60,7 @@ New CommandBar component.
 
 ### 4. Deprecated features
 
-#### Button, ButtonGroup, IconButton, Menu, MenuItem, Divider
+#### Button, ButtonGroup, IconButton, Menu, MenuItem, Divider, Card, CardBody, CardHeader
 
 These components are no longer re-exported from Saas UI. You can import them directly from Chakra UI.
 


### PR DESCRIPTION
I found there was a few other things that I needed to change imports over since upgrading.

EDIT: I'm truthfully not sure what branch to make such PRs against, but figured it was just as easy as logging an issue