### PR TITLE
chore: fix typo in terms of service

### DIFF
--- a/apps/website/src/pages/terms.tsx
+++ b/apps/website/src/pages/terms.tsx
@@ -35,7 +35,7 @@ const License = () => {
 export default License
 
 const terms = `
-Last updated 2nd of Februari, 2021
+Last updated 2nd of February, 2021
 
 By accessing our website, you are agreeing to be bound by these terms of service, and agree that you are responsible for compliance with any applicable local laws.
 


### PR DESCRIPTION
Fixes #164 

I've fixed the typo in the Terms of Service page.

@Pagebakers Kindly validate and merge the PR.