### PR TITLE
Missing logout props

### DIFF
--- a/packages/saas-ui-auth/src/provider.tsx
+++ b/packages/saas-ui-auth/src/provider.tsx
@@ -251,8 +251,8 @@ export const AuthProvider = <TUser extends User = DefaultUser>({
     [onLogin]
   )
 
-  const logOut = useCallback(async () => {
-    await onLogout()
+  const logOut = useCallback(async (options?: AuthOptions) => {
+    await onLogout(options)
     setUser(null)
     setAuthenticated(false)
   }, [onLogout])


### PR DESCRIPTION
### Introduction

This PR aims at fixing a very little bug. The logOut props are declared at the interface level, but not at the callback one. Meaning that we think we are using it on app side, but it's never received on the custom auth provider.