### PR TITLE
Update usage.mdx with note on maxFileSize prop

### DIFF
--- a/apps/website/src/pages/docs/components/forms/file-upload/usage.mdx
+++ b/apps/website/src/pages/docs/components/forms/file-upload/usage.mdx
@@ -77,6 +77,8 @@ export default function Basic() {
 
 Set `maxFiles` to increase the amount of accepted files.
 
+You can also set a maximum file size with `maxFileSize`. Note that if the component seems to not be taking your files, you may need to allow larger files or submit a smaller file.
+
 ```jsx
 import { Text, HStack, Button } from '@chakra-ui/react'
 import {


### PR DESCRIPTION
This updates the FileUpload component docs with a note mentioning a quirk in the component that could be perceived as a bug.

Maybe if i have some spare time I'll write a new feature into the component that throws a toast or some other error telling you if a file is too big for the maxFileSize. 