### PR TITLE
feat(line-chart): add custom min max values for Y axis domain

### DIFF
--- a/.changeset/loud-ducks-sneeze.md
+++ b/.changeset/loud-ducks-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@saas-ui/charts': patch
+---
+
+added minValue and maxValue to the LineChart

--- a/packages/saas-ui-charts/src/line-chart.tsx
+++ b/packages/saas-ui-charts/src/line-chart.tsx
@@ -17,20 +17,35 @@ import { ChartLegend } from './legend'
 import { createCategoryColors } from './utils'
 import { ChartTooltip } from './tooltip'
 import { BaseChartProps } from './types'
+import { AxisDomain } from 'recharts/types/util/types'
 
 export interface LineChartProps extends BaseChartProps {
   /**
    * Whether to connect null values.
    */
   connectNulls?: boolean
+
   /**
    * The curve type of the line.
    */
   curveType?: CurveType
+
   /**
    * The width of the line.
    */
   strokeWidth?: string | number
+
+  /**
+   * The lower bound of the y-axis.
+   * @default 0
+   */
+  minValue?: number | 'auto'
+
+  /**
+   * The upper bound of the y-axis.
+   * @default 'auto'
+   */
+  maxValue?: number | 'auto'
 }
 
 /**
@@ -60,6 +75,8 @@ export const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>(
       yAxisWidth = 40,
       legendHeight = 32,
       animationDuration = 500,
+      minValue = 0,
+      maxValue = 'auto',
       valueFormatter,
       tooltipContent,
       children,
@@ -71,6 +88,8 @@ export const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>(
     const getColor = (category: string) => {
       return categoryColors[category]
     }
+
+    const yAxisDomain: AxisDomain = [minValue, maxValue]
 
     return (
       <Box ref={ref} height={height} fontSize="sm">
@@ -108,6 +127,7 @@ export const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>(
               hide={!showYAxis}
               axisLine={false}
               tickLine={false}
+              domain={yAxisDomain}
               tick={{ transform: 'translate(-3, 0)' }}
               type="number"
               tickFormatter={valueFormatter}

--- a/packages/saas-ui-charts/stories/line-chart.stories.tsx
+++ b/packages/saas-ui-charts/stories/line-chart.stories.tsx
@@ -95,3 +95,34 @@ export const Multiple: Story = {
     )
   },
 }
+
+export const CustomYAxisBounds: Story = {
+  args: {
+    data: createData({
+      startDate: '2023-12-01',
+      endDate: '2023-12-31',
+      categories: ['Backend', 'Frontend'],
+      startValues: [50, 30],
+      growthRate: 1.01,
+    }),
+    height: '300px',
+    categories: ['Backend', 'Frontend'],
+    colors: ['purple', 'cyan'],
+    minValue: 20,
+    maxValue: 50
+  },
+  render: (args) => {
+    return (
+      <Card>
+        <CardHeader pb="0">
+          <Heading as="h4" fontWeight="medium" size="md">
+            Developers
+          </Heading>
+        </CardHeader>
+        <CardBody>
+          <LineChart {...args} />
+        </CardBody>
+      </Card>
+    )
+  }
+}


### PR DESCRIPTION
This PR introduces `minValue` and `maxValue` for line-charts, to allow focusing only on the values which are part of the supplied data.

- when minValue is not set, the YAxis domain's default of 0 is used
- when maxValue is not set, the YAxis domain's default of 'auto' is used
- when minValue is set, the YAxis will start rendering at this value
- when maxValue is set, the YAxis will stop rendering close to this value (if there is data with higher values it will still expand, so no worries)

Example of the default behaviour, recharts start the YAxis at 0
<img width="1169" alt="image" src="https://github.com/user-attachments/assets/5ea3a446-2880-4cfe-a15e-d9ac9c8e9ef2">

Example of the new behavior, when minValue is set to 20 and maxValue is set to 50
<img width="1160" alt="image" src="https://github.com/user-attachments/assets/3e0fc974-6d0e-4910-b1d8-8a233c0b1b15">

this will make smaller changes in values stand out more