### PR TITLE
Update recharts to v2.13 to resolve defaultProps errors

### DIFF
--- a/packages/saas-ui-charts/package.json
+++ b/packages/saas-ui-charts/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@chakra-ui/styled-system": "^2.11.1",
-    "recharts": "^2.12.7"
+    "recharts": "^2.13.0"
   },
   "peerDependencies": {
     "@chakra-ui/react": ">=2.4.8",


### PR DESCRIPTION
Updates recharts to version 2.13.0 to resolve the `defaultProps` errors