### PR TITLE
chore(forms): add bugs metadata

### DIFF
--- a/.changeset/slick-jobs-design.md
+++ b/.changeset/slick-jobs-design.md
@@ -1,0 +1,5 @@
+---
+"@saas-ui/forms": patch
+---
+
+chore(forms): add bugs metadata

--- a/packages/saas-ui-forms/package.json
+++ b/packages/saas-ui-forms/package.json
@@ -81,6 +81,9 @@
     "url": "https://github.com/saas-js/saas-ui",
     "directory": "packages/saas-ui-forms"
   },
+  "bugs": {
+    "url": "https://github.com/saas-js/saas-ui/issues"
+  },
   "keywords": [
     "react",
     "ui",


### PR DESCRIPTION
## Summary
- add the missing npm bugs.url metadata for @saas-ui/forms

## Notes
- targets the v2 branch because npm latest @saas-ui/forms is 2.11.0 from packages/saas-ui-forms
- no runtime code, dependencies, package exports, generated files, or version fields changed

## Verification
- node manifest assertion for @saas-ui/forms bugs.url
- npm pack --dry-run --ignore-scripts --json in packages/saas-ui-forms
- git diff --check