### PR TITLE
fix: use ordered list for timeline

### DIFF
--- a/packages/saas-ui-react/src/components/timeline/index.ts
+++ b/packages/saas-ui-react/src/components/timeline/index.ts
@@ -1,1 +1,1 @@
-export { Timeline } from '@chakra-ui/react/timeline'
+export * as Timeline from './timeline.tsx'

--- a/packages/saas-ui-react/src/components/timeline/timeline.tsx
+++ b/packages/saas-ui-react/src/components/timeline/timeline.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import * as React from 'react'
+import {
+  TimelineConnector,
+  TimelineContent,
+  TimelineDescription,
+  TimelineIndicator,
+  TimelineItem as ChakraTimelineItem,
+  type TimelineItemProps,
+  TimelineRoot as ChakraTimelineRoot,
+  type TimelineRootProps,
+  TimelineSeparator,
+  TimelineTitle,
+} from '@chakra-ui/react/timeline'
+
+export const Root = React.forwardRef<HTMLOListElement, TimelineRootProps>(
+  (props, ref) => {
+    return <ChakraTimelineRoot as="ol" ref={ref as React.Ref<HTMLDivElement>} {...props} />
+  }
+)
+Root.displayName = 'Timeline.Root'
+
+export const Item = React.forwardRef<HTMLLIElement, TimelineItemProps>(
+  (props, ref) => {
+    return <ChakraTimelineItem as="li" ref={ref as React.Ref<HTMLDivElement>} {...props} />
+  }
+)
+Item.displayName = 'Timeline.Item'
+
+export {
+  TimelineConnector as Connector,
+  TimelineContent as Content,
+  TimelineDescription as Description,
+  TimelineIndicator as Indicator,
+  TimelineSeparator as Separator,
+  TimelineTitle as Title,
+  useTimelineStyles,
+} from '@chakra-ui/react/timeline'
+
+export type {
+  TimelineConnectorProps as ConnectorProps,
+  TimelineContentProps as ContentProps,
+  TimelineDescriptionProps as DescriptionProps,
+  TimelineIndicatorProps as IndicatorProps,
+  TimelineItemProps as ItemProps,
+  TimelineRootProps as RootProps,
+  TimelineSeparatorProps as SeparatorProps,
+  TimelineTitleProps as TitleProps,
+} from '@chakra-ui/react/timeline'


### PR DESCRIPTION
## Summary
- Render `Timeline.Root` as an ordered list for improved accessibility.
- Render `Timeline.Item` as a list item to keep valid list semantics.
- Preserve the existing Timeline component API and styling.

## Testing
- `pnpm --filter "@saas-ui/react" build`

## Notes
- No paid services, API keys, or Docker setup were needed.
