### PR TITLE
fix(website): make the starter-kit migration actually pass signal

### DIFF
--- a/apps/website/lib/seo/saas-ui-redirects.ts
+++ b/apps/website/lib/seo/saas-ui-redirects.ts
@@ -118,12 +118,13 @@ export const saasUiRedirects: Record<string, string> = {
   // --- starter kits and auth guides now live on saas-js.com ---
   '/nextjs-starter-kit': `${SAAS_JS}/nextjs`,
   '/docs/nextjs-starter-kit': `${SAAS_JS}/docs/starter-kits/nextjs`,
-  '/docs/tanstack-router-starter-kit': `${SAAS_JS}/docs/starter-kits/nextjs`,
-  '/docs/guides/auth/clerk': `${SAAS_JS}/docs/starter-kits/nextjs/authentication`,
-  '/docs/guides/auth/supabase': `${SAAS_JS}/docs/starter-kits/nextjs/authentication`,
-  '/docs/guides/auth/magic': `${SAAS_JS}/docs/starter-kits/nextjs/authentication`,
-  '/docs/components/authentication/auth': `${SAAS_JS}/docs/starter-kits/nextjs/authentication`,
-  '/docs/components/authentication/auth-provider': `${SAAS_JS}/docs/starter-kits/nextjs/authentication`,
+  '/docs/tanstack-router-starter-kit': `${SAAS_JS}/docs/starter-kits/tanstack-start`,
+  // There is no /authentication index page — better-auth is the auth doc now.
+  '/docs/guides/auth/clerk': `${SAAS_JS}/docs/starter-kits/nextjs/authentication/better-auth`,
+  '/docs/guides/auth/supabase': `${SAAS_JS}/docs/starter-kits/nextjs/authentication/better-auth`,
+  '/docs/guides/auth/magic': `${SAAS_JS}/docs/starter-kits/nextjs/authentication/better-auth`,
+  '/docs/components/authentication/auth': `${SAAS_JS}/docs/starter-kits/nextjs/authentication/better-auth`,
+  '/docs/components/authentication/auth-provider': `${SAAS_JS}/docs/starter-kits/nextjs/authentication/better-auth`,
   '/pricing/figma': '/pricing',
 }
 
@@ -133,7 +134,10 @@ export const saasUiRedirects: Record<string, string> = {
  */
 const prefixRedirects: Array<[string, string]> = [
   ['/docs/nextjs-starter-kit', `${SAAS_JS}/docs/starter-kits/nextjs`],
-  ['/docs/tanstack-router-starter-kit', `${SAAS_JS}/docs/starter-kits/nextjs`],
+  [
+    '/docs/tanstack-router-starter-kit',
+    `${SAAS_JS}/docs/starter-kits/tanstack-start`,
+  ],
   ['/blog', `${SAAS_JS}/blog`],
 ]
 


### PR DESCRIPTION
Follow-up to #310, which merged before these landed. Both changes exist for one reason: **most sales come through Google, and the starter-kit search channel is currently at zero.**

## Context

The starter-kit pages held a steady 88–119 clicks/month for eleven months — *including* the months right after the move to saas-js.com. The move didn't break the channel. What broke it: from December 2025 both domains served the same content with no redirects and no canonicals, so Google split the signal. `/nextjs-starter-kit` fell from average position 8.6 to 17.7 in one month and bled out over eight. Then July's restructure 404'd it. saas-js.com never picked it up — max 3 clicks/month, ever.

| Phase | saas-ui.dev clicks/mo | saas-js.com clicks/mo |
|---|---:|---:|
| Before the move (May–Nov 2025) | 88–112 | — |
| Both domains live (Dec 2025–Mar 2026) | 95–110 | 1–3 |
| Signal splitting (Apr–Jul 2026) | 64 → 25 | 0–2 |
| After the 404s (Aug–Sep 2026) | 5 → 0 | 0 |

## 1. Two redirect targets were wrong

A redirect to a 404 is worse than the 404 it replaces — the crawler takes a hop and still fails, passing nothing.

- **The auth guides pointed at a page that doesn't exist.** `/docs/starter-kits/nextjs/authentication` 404s on saas-js.com; there's no index for that section, only `better-auth` and `customize-auth-screens`. Now points at `/docs/starter-kits/nextjs/authentication/better-auth`. Affects `/docs/guides/auth/{clerk,supabase,magic}` and the two auth component docs — `/docs/guides/auth/clerk` alone carried **3,376 impressions** in 90 days.
- **The TanStack routes pointed at the Next.js kit.** saas-js.com has a separate `starter-kits/tanstack-start` section.

All five cross-domain targets verified 200: `/nextjs`, `/docs/starter-kits/nextjs`, `/docs/starter-kits/tanstack-start`, `/docs/starter-kits/nextjs/authentication/better-auth`, `/blog`.

## 2. Every link to the starter kits pointed at the homepage

saas-ui.dev has the authority — roughly 2,000 clicks/month against saas-js.com's 30–50 — so its outbound links are the main way that authority reaches the kits.

The footer link whose anchor text is literally **"Next.js starter kit"** pointed at `https://saas-js.com`, not `/nextjs`. The page trying to rank for that exact phrase, currently at position 45, was getting none of the relevance signal. That's now fixed, along with the TanStack entry.

Every cross-domain link also now uses `www.saas-js.com`; the apex 308s to www, so each was spending a redirect hop.

Brand mentions whose anchor text is "saas-js.com", and the "View starter kits" button that covers both kits, still point at the homepage — that's the honest target for those.

## Verified

Rendered against a dev server with a `Host: saas-ui.dev` header: the footer now emits `<a href="https://www.saas-js.com/nextjs">Next.js starter kit</a>` on the marketing pages, no apex links remain anywhere in the source, and no server errors.

## Not in this PR

The `/nextjs` page's `<h1>` is "Your AI agents are only as good as your codebase" — no target terms anywhere in it. The page that ranked at position 8 used "Next.js starter kit for building intuitive SaaS products". That's a positioning call rather than a bug, so I've left it alone, but it's the largest remaining on-page gap.