### PR TITLE
fix(website): route starter-kit links to the kit pages, not the homepage

### DIFF
--- a/apps/website/app/ui/(landing)/pricing/components/cta.tsx
+++ b/apps/website/app/ui/(landing)/pricing/components/cta.tsx
@@ -34,7 +34,7 @@ export function CTA() {
               <LinkButton
                 variant="glass"
                 colorPalette="cyan"
-                href="https://saas-js.com"
+                href="https://www.saas-js.com"
                 alignSelf="flex-start"
               >
                 View starter kits <ActionArrow />

--- a/apps/website/app/ui/(landing)/pricing/components/hero.tsx
+++ b/apps/website/app/ui/(landing)/pricing/components/hero.tsx
@@ -39,7 +39,7 @@ export function Hero() {
       >
         <Text>
           Our starter kits have moved to the{' '}
-          <Link href="https://saas-js.com" fontWeight="medium">
+          <Link href="https://www.saas-js.com" fontWeight="medium">
             saas-js.com
           </Link>
           .

--- a/apps/website/components/site/footer.section.tsx
+++ b/apps/website/components/site/footer.section.tsx
@@ -23,10 +23,13 @@ const linkTree = [
       { label: 'Blocks', href: '/pro/blocks' },
       { label: 'Figma UI kit', href: '/pro/figma' },
 
-      { label: 'Next.js starter kit', href: 'https://saas-js.com' },
+      // Point each kit at its own page rather than the saas-js.com homepage.
+      // These are sitewide links with exact-match anchor text, so they are the
+      // main way saas-ui.dev's authority reaches the pages that need it.
+      { label: 'Next.js starter kit', href: 'https://www.saas-js.com/nextjs' },
       {
         label: 'Tanstack Start starter kit',
-        href: 'https://saas-js.com/tanstack-start',
+        href: 'https://www.saas-js.com/tanstack-start',
       },
     ],
   },

--- a/apps/website/components/site/header.section.tsx
+++ b/apps/website/components/site/header.section.tsx
@@ -159,13 +159,13 @@ export const HeaderSection = () => {
         <Text fontWeight="medium">Looking for our SaaS starter kits?</Text>
         <Text>
           They're now available at{' '}
-          <Link href="https://saas-js.com">saas-js.com</Link>
+          <Link href="https://www.saas-js.com">saas-js.com</Link>
         </Text>
 
         <LinkButton
           variant="outline"
           colorPalette="accent"
-          href="https://saas-js.com"
+          href="https://www.saas-js.com"
           size="xs"
         >
           Learn more <ActionArrow />


### PR DESCRIPTION
Follow-up to #313, which merged before this commit landed on the branch. This is the internal-linking half of that PR's description — the redirect-target half is already in.

## Why this one matters

saas-ui.dev has the authority: roughly **2,000 clicks/month** against saas-js.com's **30–50**. Its outbound links are the main way that authority reaches the starter kits, which are currently at zero organic clicks and sitting at position 42–47 for the money terms.

Every one of those links pointed at the saas-js.com homepage. Including this, in the sitewide footer:

```ts
{ label: 'Next.js starter kit', href: 'https://saas-js.com' }
```

Exact-match anchor text for the phrase `/nextjs` is trying to rank for, pointed at the homepage instead. The page that needs the relevance signal was getting none of it.

## Changes

- Footer **"Next.js starter kit"** → `/nextjs`, **"Tanstack Start starter kit"** → `/tanstack-start`. Sitewide on the marketing pages, with exact-match anchor text.
- Every cross-domain link now uses `www.saas-js.com`. The apex 308s to www, so each link was spending a redirect hop.

Brand mentions whose anchor text is "saas-js.com", and the "View starter kits" button that covers both kits, still point at the homepage — that's the honest target for those.

## Verified

Rendered against a dev server with a `Host: saas-ui.dev` header:

- Footer emits `<a href="https://www.saas-js.com/nextjs">Next.js starter kit</a>` on `/`, `/pricing` and `/blocks`
- No apex links remain anywhere in the source
- No server errors

## Still not in any PR

The `/nextjs` page's `<h1>` is "Your AI agents are only as good as your codebase" — no target terms in it. The version that ranked at position 8 used "Next.js starter kit for building intuitive SaaS products". That's a positioning call rather than a bug, so it's left alone, but it's the largest remaining on-page gap and the cheapest thing to test.