### PR TITLE
fix(website): resolve the legacy sitemap URLs instead of 404ing

### DIFF
--- a/apps/website/lib/seo/saas-ui-redirects.ts
+++ b/apps/website/lib/seo/saas-ui-redirects.ts
@@ -126,6 +126,18 @@ export const saasUiRedirects: Record<string, string> = {
   '/docs/components/authentication/auth': `${SAAS_JS}/docs/starter-kits/nextjs/authentication/better-auth`,
   '/docs/components/authentication/auth-provider': `${SAAS_JS}/docs/starter-kits/nextjs/authentication/better-auth`,
   '/pricing/figma': '/pricing',
+
+  // Legacy sitemap URLs still registered in Search Console, submitted between
+  // 2022 and 2024 and reporting "Couldn't fetch" since the July restructure.
+  // They cannot be removed from the report — the entries were submitted against
+  // the old URL-prefix properties — and deleting a sitemap there is cosmetic
+  // anyway, since Google keeps the URLs it already knows. Pointing them at the
+  // current sitemap turns four standing errors into a sitemap Google already
+  // re-checks on a schedule. (www.saas-ui.dev/sitemap.xml already resolves via
+  // the www → apex redirect.)
+  '/pages.xml': '/sitemap.xml',
+  '/docs.xml': '/sitemap.xml',
+  '/blog.xml': '/sitemap.xml',
 }
 
 /**


### PR DESCRIPTION
Search Console still lists five sitemaps for saas-ui.dev, submitted between 2022 and 2024, all showing **"Couldn't fetch"** with last-read dates of 1–9 July 2026 — the restructure window again.

They can't be removed from the report: they were submitted against the old URL-prefix properties, not the domain property. And per [Google's own documentation](https://support.google.com/webmasters/answer/7451001), removing one is cosmetic regardless:

> Deleting a sitemap removes the sitemap from this report, but Google won't forget the sitemap or any URLs listed in it.

So rather than leave them broken, point them at the current sitemap.

## Before

| Submitted URL | Status |
|---|---|
| `saas-ui.dev/pages.xml` | 404 |
| `saas-ui.dev/docs.xml` | 404 |
| `www.saas-ui.dev/docs.xml` | 308 → 404 |
| `www.saas-ui.dev/blog.xml` | 308 → 404 |
| `www.saas-ui.dev/sitemap.xml` | 308 → **200** (already fixed by #310) |

## After

`/pages.xml`, `/docs.xml` and `/blog.xml` now 308 to `/sitemap.xml`, which serves the current 226-URL sitemap. That covers all four remaining entries — the two `www` ones collapse onto the same apex paths.

These are URLs Google has been re-checking on a schedule for years. Having them serve the live sitemap is worth more than having them 404, and it clears four standing errors in a report that's otherwise hard to read.

## Verified

Against a dev server with a `Host: saas-ui.dev` header:

- `/pages.xml`, `/docs.xml`, `/blog.xml` → 308 → `/sitemap.xml` → 200, 226 `<loc>` entries
- `/sitemap.xml` itself still 200 and does not redirect to itself
- `/robots.txt`, `/`, `/docs/components/app-shell` unchanged
- saas-js.com unaffected — the redirect map only applies to the saas-ui host, and `saas-js.com/docs.xml` still 404s as it should

## Note on the old format

The originals were RSS feeds, which Google accepts as a sitemap format and labelled "RSS" in the report. The replacement is a standard `urlset`; Google will re-read and reclassify on the next fetch.